### PR TITLE
fix: generated file name in gerber viewer

### DIFF
--- a/apps/view/src/render/models.ts
+++ b/apps/view/src/render/models.ts
@@ -78,9 +78,15 @@ export async function boardToStackups(
   })
 }
 
-export async function stackupToZipBlob(stackup: Stackup): Promise<Blob> {
+export async function stackupToZipBlob(stackup: Stackup, board: Board): Promise<Blob> {
+  let fileName = ''
+  if (board.name) {
+    fileName = board.name
+  } else {
+    fileName = DEFAULT_BOARD_NAME
+  }
   const files = stackup.layers
-    .filter(layer => layer.converter.layer.length > 0)
+    .filter((layer) => layer.converter.layer.length > 0)
     .reduce(
       (result, layer) =>
         result.concat({
@@ -88,8 +94,8 @@ export async function stackupToZipBlob(stackup: Stackup): Promise<Blob> {
           contents: render(layer.converter, layer.options.id),
         }),
       [
-        {name: 'top.svg', contents: stackup.top.svg},
-        {name: 'bottom.svg', contents: stackup.bottom.svg},
+        {name: `${fileName}_PCB-Image-TOP.svg`, contents: stackup.top.svg},
+        {name: `${fileName}_PCB-Image-BOT.svg`, contents: stackup.bottom.svg},
       ]
     )
 

--- a/apps/view/src/render/models.ts
+++ b/apps/view/src/render/models.ts
@@ -77,8 +77,10 @@ export async function boardToStackups(
     return Promise.all([selfContainedStackup, sharedStackup])
   })
 }
-
-export async function stackupToZipBlob(stackup: Stackup, board: Board): Promise<Blob> {
+  export async function stackupToZipBlob(
+    stackup: Stackup,
+    board: Board
+  ): Promise<Blob> {
   let fileName = ''
   if (board.name) {
     fileName = board.name
@@ -86,7 +88,7 @@ export async function stackupToZipBlob(stackup: Stackup, board: Board): Promise<
     fileName = DEFAULT_BOARD_NAME
   }
   const files = stackup.layers
-    .filter((layer) => layer.converter.layer.length > 0)
+  .filter(layer => layer.converter.layer.length > 0)
     .reduce(
       (result, layer) =>
         result.concat({

--- a/apps/view/src/render/worker.ts
+++ b/apps/view/src/render/worker.ts
@@ -135,7 +135,7 @@ ctx.onmessage = function receive(event) {
         boardToStackups(board)
           .then(stackups => {
             const [selfContained] = stackups
-            return stackupToZipBlob(selfContained)
+            return stackupToZipBlob(selfContained, board)
           })
           .then(blob => ctx.postMessage(boardPackaged(id, board.name, blob)))
       )


### PR DESCRIPTION
re https://app.asana.com/1/5641712848301/project/1202488269220482/task/1210483692205165

<img width="663" alt="image" src="https://github.com/user-attachments/assets/c2bd4c67-9825-44b1-9575-5f0686211f3e" />

https://github.com/user-attachments/assets/c7095f35-64ce-4504-9078-6ff9e30a416c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exported PCB image files in ZIP archives now include the board name in their filenames for easier identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->