### PR TITLE
feat: ignore files from ios compression

### DIFF
--- a/apps/view/src/render/files.ts
+++ b/apps/view/src/render/files.ts
@@ -77,12 +77,20 @@ function fileReader(file: File): FileStream {
 
 async function zipReader(file: Blob): PromiseArray<FileStream> {
   return import('jszip')
-        .then(ZipModule => ZipModule.loadAsync(file))
-        .then(zip =>
-            Object.keys(zip.files)
-                .filter(name => !zip.files[name].dir && !name.startsWith('__MACOSX/') && !name.startsWith('._'))
-                .map(name => {
-                    return pump<FileStream>(zip.files[name].nodeStream(), new FileStream(name));
-                })
+    .then(ZipModule => ZipModule.loadAsync(file))
+    .then(zip =>
+      Object.keys(zip.files)
+        .filter(
+          name =>
+            !zip.files[name].dir &&
+            !name.startsWith('__MACOSX/') &&
+            !name.startsWith('._')
         )
+        .map(name => {
+          return pump<FileStream>(
+            zip.files[name].nodeStream(),
+            new FileStream(name)
+          )
+        })
+    )
 }

--- a/apps/view/src/render/files.ts
+++ b/apps/view/src/render/files.ts
@@ -77,12 +77,12 @@ function fileReader(file: File): FileStream {
 
 async function zipReader(file: Blob): PromiseArray<FileStream> {
   return import('jszip')
-    .then(ZipModule => ZipModule.loadAsync(file))
-    .then(zip =>
-      Object.keys(zip.files)
-        .filter(name => !zip.files[name].dir)
-        .map(name =>
-          pump<FileStream>(zip.files[name].nodeStream(), new FileStream(name))
+        .then(ZipModule => ZipModule.loadAsync(file))
+        .then(zip =>
+            Object.keys(zip.files)
+                .filter(name => !zip.files[name].dir && !name.startsWith('__MACOSX/') && !name.startsWith('._'))
+                .map(name => {
+                    return pump<FileStream>(zip.files[name].nodeStream(), new FileStream(name));
+                })
         )
-    )
 }


### PR DESCRIPTION
re : https://app.asana.com/0/home/1202488269211191/1210997869039216

Ignore files created from macos file compression.

SC:
--
<img width="1162" height="895" alt="image" src="https://github.com/user-attachments/assets/cc734649-e9c9-41dc-9197-40d6c6925fdc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file extraction from zip archives by excluding unnecessary macOS system files (such as files starting with `__MACOSX/` or `._`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->